### PR TITLE
Handle boards without channels

### DIFF
--- a/app/[boardId]/_components/board-empty-state.tsx
+++ b/app/[boardId]/_components/board-empty-state.tsx
@@ -1,0 +1,24 @@
+type BoardEmptyStateProps = {
+  boardDisplayName: string;
+  boardSlug: string;
+};
+
+export function BoardEmptyState({
+  boardDisplayName,
+  boardSlug,
+}: BoardEmptyStateProps) {
+  return (
+    <div className="channel-view">
+      <div className="channel-scroll">
+        <div className="channel-empty-state">
+          <h2>첫 채널을 만들어보세요</h2>
+          <p>
+            {boardDisplayName} 보드(/{boardSlug})에는 아직 채널이 없습니다. 관리자 모드에서
+            채널을 추가해 자료를 정리할 주제를 만들어보세요.
+          </p>
+          <p>채널이 생성되면 이 화면은 자동으로 첫 번째 채널로 이동합니다.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[boardId]/_components/board-sidebar.tsx
+++ b/app/[boardId]/_components/board-sidebar.tsx
@@ -1,0 +1,37 @@
+import { BoardSidebarNav } from "../sidebar-nav";
+
+type ChannelNavItem = {
+  id: string;
+  name: string;
+  slug: string;
+  isDefault: boolean;
+};
+
+type BoardSidebarProps = {
+  boardSlug: string;
+  boardName: string;
+  boardDescription: string | null;
+  channels: ChannelNavItem[];
+};
+
+export function BoardSidebar({
+  boardSlug,
+  boardName,
+  boardDescription,
+  channels,
+}: BoardSidebarProps) {
+  return (
+    <aside className="workspace-sidebar">
+      <div className="workspace-board">
+        <span className="workspace-board-slug">/{boardSlug}</span>
+        <h1>{boardName}</h1>
+        {boardDescription ? (
+          <p>{boardDescription}</p>
+        ) : (
+          <p className="workspace-board-muted">설명이 아직 등록되지 않았습니다.</p>
+        )}
+      </div>
+      <BoardSidebarNav boardSlug={boardSlug} channels={channels} />
+    </aside>
+  );
+}

--- a/app/[boardId]/_components/workspace-shell.tsx
+++ b/app/[boardId]/_components/workspace-shell.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+type WorkspaceShellProps = {
+  sidebar: ReactNode;
+  children: ReactNode;
+};
+
+export function WorkspaceShell({ sidebar, children }: WorkspaceShellProps) {
+  return (
+    <div className="workspace">
+      {sidebar}
+      <section className="workspace-content">{children}</section>
+    </div>
+  );
+}

--- a/app/[boardId]/layout.tsx
+++ b/app/[boardId]/layout.tsx
@@ -6,7 +6,9 @@ import { asc, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { boards, channels } from "@/db/schema";
 
-import { BoardSidebarNav } from "./sidebar-nav";
+import { BoardEmptyState } from "./_components/board-empty-state";
+import { BoardSidebar } from "./_components/board-sidebar";
+import { WorkspaceShell } from "./_components/workspace-shell";
 
 type BoardLayoutProps = {
   children: ReactNode;
@@ -89,46 +91,24 @@ export default async function BoardLayout({
 
   const boardDisplayName = boardRecord.name ?? boardRecord.slug;
   const hasChannels = channelList.length > 0;
-
-  return (
-    <div className="workspace">
-      <aside className="workspace-sidebar">
-        <div className="workspace-board">
-          <span className="workspace-board-slug">/{boardRecord.slug}</span>
-          <h1>{boardRecord.name}</h1>
-          {boardRecord.description ? (
-            <p>{boardRecord.description}</p>
-          ) : (
-            <p className="workspace-board-muted">
-              설명이 아직 등록되지 않았습니다.
-            </p>
-          )}
-        </div>
-        <BoardSidebarNav
-          boardSlug={boardRecord.slug}
-          channels={channelList}
-        />
-      </aside>
-      <section className="workspace-content">
-        {hasChannels ? (
-          children
-        ) : (
-          <div className="channel-view">
-            <div className="channel-scroll">
-              <div className="channel-empty-state">
-                <h2>첫 채널을 만들어보세요</h2>
-                <p>
-                  {boardDisplayName} 보드에는 아직 채널이 없습니다. 관리자 모드에서
-                  채널을 추가해 자료를 정리할 주제를 만들어보세요.
-                </p>
-                <p>
-                  채널이 생성되면 이 화면은 자동으로 첫 번째 채널로 이동합니다.
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
-      </section>
-    </div>
+  const hasRenderableChildren = children != null;
+  const sidebar = (
+    <BoardSidebar
+      boardSlug={boardRecord.slug}
+      boardName={boardDisplayName}
+      boardDescription={boardRecord.description}
+      channels={channelList}
+    />
   );
+
+  const content = hasChannels || hasRenderableChildren ? (
+    children
+  ) : (
+    <BoardEmptyState
+      boardDisplayName={boardDisplayName}
+      boardSlug={boardRecord.slug}
+    />
+  );
+
+  return <WorkspaceShell sidebar={sidebar}>{content}</WorkspaceShell>;
 }

--- a/app/[boardId]/layout.tsx
+++ b/app/[boardId]/layout.tsx
@@ -87,6 +87,9 @@ export default async function BoardLayout({
       isDefault: channel.id === boardRecord.defaultChannelId,
     }));
 
+  const boardDisplayName = boardRecord.name ?? boardRecord.slug;
+  const hasChannels = channelList.length > 0;
+
   return (
     <div className="workspace">
       <aside className="workspace-sidebar">
@@ -106,7 +109,26 @@ export default async function BoardLayout({
           channels={channelList}
         />
       </aside>
-      <section className="workspace-content">{children}</section>
+      <section className="workspace-content">
+        {hasChannels ? (
+          children
+        ) : (
+          <div className="channel-view">
+            <div className="channel-scroll">
+              <div className="channel-empty-state">
+                <h2>첫 채널을 만들어보세요</h2>
+                <p>
+                  {boardDisplayName} 보드에는 아직 채널이 없습니다. 관리자 모드에서
+                  채널을 추가해 자료를 정리할 주제를 만들어보세요.
+                </p>
+                <p>
+                  채널이 생성되면 이 화면은 자동으로 첫 번째 채널로 이동합니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/app/[boardId]/page.tsx
+++ b/app/[boardId]/page.tsx
@@ -18,6 +18,7 @@ export default async function BoardPage({ params }: BoardPageProps) {
   const boardRecord = db
     .select({
       id: boards.id,
+      name: boards.name,
       slug: boards.slug,
       defaultChannelId: boards.defaultChannelId,
     })
@@ -55,9 +56,26 @@ export default async function BoardPage({ params }: BoardPageProps) {
     resolvedChannelSlug = fallbackChannel?.slug ?? null;
   }
 
-  if (!resolvedChannelSlug) {
-    notFound();
+  if (resolvedChannelSlug) {
+    redirect(`/${boardRecord.slug}/${resolvedChannelSlug}`);
   }
 
-  redirect(`/${boardRecord.slug}/${resolvedChannelSlug}`);
+  const boardDisplayName = boardRecord.name ?? boardRecord.slug;
+
+  return (
+    <div className="channel-view">
+      <div className="channel-scroll">
+        <div className="channel-empty-state">
+          <h2>첫 채널을 만들어보세요</h2>
+          <p>
+            {boardDisplayName} 보드에는 아직 채널이 없습니다. 관리자 모드에서
+            채널을 추가해 자료를 정리할 주제를 만들어보세요.
+          </p>
+          <p>
+            채널이 생성되면 이 화면은 자동으로 첫 번째 채널로 이동합니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/app/[boardId]/page.tsx
+++ b/app/[boardId]/page.tsx
@@ -60,22 +60,5 @@ export default async function BoardPage({ params }: BoardPageProps) {
     redirect(`/${boardRecord.slug}/${resolvedChannelSlug}`);
   }
 
-  const boardDisplayName = boardRecord.name ?? boardRecord.slug;
-
-  return (
-    <div className="channel-view">
-      <div className="channel-scroll">
-        <div className="channel-empty-state">
-          <h2>첫 채널을 만들어보세요</h2>
-          <p>
-            {boardDisplayName} 보드에는 아직 채널이 없습니다. 관리자 모드에서
-            채널을 추가해 자료를 정리할 주제를 만들어보세요.
-          </p>
-          <p>
-            채널이 생성되면 이 화면은 자동으로 첫 번째 채널로 이동합니다.
-          </p>
-        </div>
-      </div>
-    </div>
-  );
+  return null;
 }

--- a/app/[boardId]/page.tsx
+++ b/app/[boardId]/page.tsx
@@ -4,6 +4,8 @@ import { asc, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { boards, channels } from "@/db/schema";
 
+import { BoardEmptyState } from "./_components/board-empty-state";
+
 type BoardPageProps = {
   params: {
     boardId: string;
@@ -60,5 +62,12 @@ export default async function BoardPage({ params }: BoardPageProps) {
     redirect(`/${boardRecord.slug}/${resolvedChannelSlug}`);
   }
 
-  return null;
+  const boardDisplayName = boardRecord.name ?? boardRecord.slug;
+
+  return (
+    <BoardEmptyState
+      boardDisplayName={boardDisplayName}
+      boardSlug={boardRecord.slug}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- show a board-level empty state when the board has no channels instead of throwing a 404
- reuse the existing channel empty state styling to guide users toward creating their first channel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd53816f4c83288d6f0313876f0ddc