### PR TITLE
Handle blank channel slugs on board landing

### DIFF
--- a/app/[boardId]/page.tsx
+++ b/app/[boardId]/page.tsx
@@ -10,6 +10,51 @@ type BoardPageProps = {
   };
 };
 
+type ChannelSlugRow = {
+  slug: string;
+} | null;
+
+type BoardSummary = {
+  slug: string;
+  name: string;
+  description: string | null;
+};
+
+type ChannelResolutionResult =
+  | { type: "redirect"; slug: string }
+  | { type: "empty" }
+  | { type: "invalid"; reason: "blank-slug"; source: "default" | "first" };
+
+export function resolveBoardChannelTarget({
+  defaultChannel,
+  fallbackChannel,
+}: {
+  defaultChannel: ChannelSlugRow;
+  fallbackChannel: ChannelSlugRow;
+}): ChannelResolutionResult {
+  if (defaultChannel) {
+    const trimmedDefaultSlug = defaultChannel.slug.trim();
+
+    if (trimmedDefaultSlug.length === 0) {
+      return { type: "invalid", reason: "blank-slug", source: "default" };
+    }
+
+    return { type: "redirect", slug: trimmedDefaultSlug };
+  }
+
+  if (!fallbackChannel) {
+    return { type: "empty" };
+  }
+
+  const trimmedFallbackSlug = fallbackChannel.slug.trim();
+
+  if (trimmedFallbackSlug.length === 0) {
+    return { type: "invalid", reason: "blank-slug", source: "first" };
+  }
+
+  return { type: "redirect", slug: trimmedFallbackSlug };
+}
+
 export const dynamic = "force-dynamic";
 
 export default async function BoardPage({ params }: BoardPageProps) {
@@ -19,6 +64,8 @@ export default async function BoardPage({ params }: BoardPageProps) {
     .select({
       id: boards.id,
       slug: boards.slug,
+      name: boards.name,
+      description: boards.description,
       defaultChannelId: boards.defaultChannelId,
     })
     .from(boards)
@@ -30,34 +77,82 @@ export default async function BoardPage({ params }: BoardPageProps) {
     notFound();
   }
 
-  let resolvedChannelSlug: string | null = null;
+  const boardSummary: BoardSummary = {
+    slug: boardRecord.slug,
+    name: boardRecord.name,
+    description: boardRecord.description ?? null,
+  };
 
   if (boardRecord.defaultChannelId) {
-    const channel = db
-      .select({ slug: channels.slug })
-      .from(channels)
-      .where(eq(channels.id, boardRecord.defaultChannelId))
-      .limit(1)
-      .all()[0];
+    const channel =
+      db
+        .select({ slug: channels.slug })
+        .from(channels)
+        .where(eq(channels.id, boardRecord.defaultChannelId))
+        .limit(1)
+        .all()[0] ?? null;
 
-    resolvedChannelSlug = channel?.slug ?? null;
+    const resolution = resolveBoardChannelTarget({
+      defaultChannel: channel,
+      fallbackChannel: null,
+    });
+
+    if (resolution.type === "redirect") {
+      redirect(`/${boardRecord.slug}/${resolution.slug}`);
+    }
+
+    if (resolution.type === "invalid") {
+      notFound();
+    }
   }
 
-  if (!resolvedChannelSlug) {
-    const fallbackChannel = db
+  const fallbackChannel =
+    db
       .select({ slug: channels.slug })
       .from(channels)
       .where(eq(channels.boardId, boardRecord.id))
       .orderBy(asc(channels.orderIndex), asc(channels.createdAt))
       .limit(1)
-      .all()[0];
+      .all()[0] ?? null;
 
-    resolvedChannelSlug = fallbackChannel?.slug ?? null;
+  const resolution = resolveBoardChannelTarget({
+    defaultChannel: null,
+    fallbackChannel,
+  });
+
+  if (resolution.type === "redirect") {
+    redirect(`/${boardRecord.slug}/${resolution.slug}`);
   }
 
-  if (!resolvedChannelSlug) {
+  if (resolution.type === "invalid") {
     notFound();
   }
 
-  redirect(`/${boardRecord.slug}/${resolvedChannelSlug}`);
+  return <BoardEmptyState board={boardSummary} />;
+}
+
+function BoardEmptyState({ board }: { board: BoardSummary }) {
+  return (
+    <div className="board-empty">
+      <header className="board-header">
+        <div className="board-title-row">
+          <span className="board-slug">/{board.slug}</span>
+          <h1>{board.name}</h1>
+        </div>
+        {board.description ? (
+          <p className="board-description">{board.description}</p>
+        ) : (
+          <p className="board-description board-description--muted">
+            설명이 아직 등록되지 않았습니다.
+          </p>
+        )}
+      </header>
+      <div className="channel-empty-state" role="status">
+        <h2>채널이 아직 없습니다</h2>
+        <p>
+          관리자가 새 채널을 만들면 이 보드에서 메시지를 주고받을 수 있습니다.
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "drizzle-kit": "^0.31.4",
         "eslint": "8.57.0",
         "eslint-config-next": "14.2.3",
+        "tsx": "^4.7.0",
         "typescript": "5.4.2"
       }
     },
@@ -3668,6 +3669,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6385,6 +6401,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "tsx --test tests/board-page.test.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate"
   },
@@ -25,6 +26,7 @@
     "drizzle-kit": "^0.31.4",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.3",
-    "typescript": "5.4.2"
+    "typescript": "5.4.2",
+    "tsx": "^4.7.0"
   }
 }

--- a/tests/board-page.test.ts
+++ b/tests/board-page.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { resolveBoardChannelTarget } from "../app/[boardId]/page";
+
+describe("resolveBoardChannelTarget", () => {
+  it("prefers the default channel slug when present", () => {
+    const result = resolveBoardChannelTarget({
+      defaultChannel: { slug: "default" },
+      fallbackChannel: null,
+    });
+
+    assert.deepStrictEqual(result, {
+      type: "redirect",
+      slug: "default",
+    });
+  });
+
+  it("flags a blank default channel slug as invalid", () => {
+    const result = resolveBoardChannelTarget({
+      defaultChannel: { slug: "   " },
+      fallbackChannel: null,
+    });
+
+    assert.deepStrictEqual(result, {
+      type: "invalid",
+      reason: "blank-slug",
+      source: "default",
+    });
+  });
+
+  it("redirects using the first channel when no default is configured", () => {
+    const result = resolveBoardChannelTarget({
+      defaultChannel: null,
+      fallbackChannel: { slug: "alpha" },
+    });
+
+    assert.deepStrictEqual(result, {
+      type: "redirect",
+      slug: "alpha",
+    });
+  });
+
+  it("does not treat a blank first channel slug as an empty board", () => {
+    const result = resolveBoardChannelTarget({
+      defaultChannel: null,
+      fallbackChannel: { slug: " \t\n" },
+    });
+
+    assert.deepStrictEqual(result, {
+      type: "invalid",
+      reason: "blank-slug",
+      source: "first",
+    });
+  });
+
+  it("returns an empty-state signal only when there is no channel row", () => {
+    const result = resolveBoardChannelTarget({
+      defaultChannel: null,
+      fallbackChannel: null,
+    });
+
+    assert.deepStrictEqual(result, { type: "empty" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper to distinguish missing channel rows from blank slugs on board landing and render a board empty state only for the former
- render a simple board empty state instead of redirecting when no channels exist
- add node:test coverage for the board channel resolution helper and wire up a tsx-powered npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd743970608328bd20e1e0ddc41f15