### PR TITLE
Add aria-current for active channel links

### DIFF
--- a/app/[boardId]/sidebar-nav.tsx
+++ b/app/[boardId]/sidebar-nav.tsx
@@ -41,6 +41,7 @@ export function BoardSidebarNav({
                 <Link
                   href={`/${boardSlug}/${channel.slug}`}
                   className="channel-link"
+                  aria-current={isActive ? "page" : undefined}
                   data-active={isActive ? "true" : "false"}
                 >
                   <div className="channel-link-main">


### PR DESCRIPTION
## Summary
- add aria-current to sidebar channel links when active using existing isActive logic
- preserve the data-active attribute to keep current styling behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd7eef2fb083289a126a68faceed54