### PR TITLE
Use <main> for board workspace content

### DIFF
--- a/app/[boardId]/layout.tsx
+++ b/app/[boardId]/layout.tsx
@@ -106,7 +106,7 @@ export default async function BoardLayout({
           channels={channelList}
         />
       </aside>
-      <section className="workspace-content">{children}</section>
+      <main className="workspace-content">{children}</main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the board workspace container in the board layout with a semantic `<main>` element while preserving styling

## Testing
- npm run lint
- npm run dev (manually verified the `/default` workspace retains the `.workspace-content` styling)


------
https://chatgpt.com/codex/tasks/task_e_68cd7f9ef2808328bc4d80036a793a11