### PR TITLE
Use deterministic formatting for rendered timestamps

### DIFF
--- a/app/[boardId]/[channelId]/page.tsx
+++ b/app/[boardId]/[channelId]/page.tsx
@@ -5,6 +5,7 @@ import { and, asc, eq } from "drizzle-orm";
 
 import { db } from "@/db/client";
 import { boards, channels, items } from "@/db/schema";
+import { formatDateTime } from "@/lib/date-format";
 
 const ITEM_TYPE_LABELS: Record<"text" | "file" | "link", string> = {
   text: "텍스트",
@@ -125,10 +126,7 @@ export default async function ChannelPage({ params }: ChannelPageProps) {
           <ol className="message-list">
             {channelItems.map((item) => {
               const createdAtLabel = item.createdAt
-                ? item.createdAt.toLocaleString("ko-KR", {
-                    dateStyle: "medium",
-                    timeStyle: "short",
-                  })
+                ? formatDateTime(item.createdAt) || "시간 정보 없음"
                 : "시간 정보 없음";
               const createdAtIso = item.createdAt
                 ? item.createdAt.toISOString()

--- a/app/db-test/page.tsx
+++ b/app/db-test/page.tsx
@@ -7,6 +7,7 @@ import { eq, desc } from "drizzle-orm";
 import { db } from "@/db/client";
 import { createBoardWithDefaultChannel } from "@/db/commands";
 import { boards } from "@/db/schema";
+import { formatDateTime } from "@/lib/date-format";
 
 export const metadata: Metadata = {
   title: "DB 테스트 | pile",
@@ -100,10 +101,10 @@ export default async function DbTestPage() {
                     <dt>생성 시각</dt>
                     <dd>
                       {board.createdAt
-                        ? board.createdAt.toLocaleString("ko-KR", {
+                        ? formatDateTime(board.createdAt, {
                             dateStyle: "short",
-                            timeStyle: "medium"
-                          })
+                            timeStyle: "medium",
+                          }) || "-"
                         : "-"}
                     </dd>
                   </div>

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -1,0 +1,38 @@
+const LOCALE = "ko-KR";
+const TIME_ZONE = "Asia/Seoul";
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+type FormatDateTimeOptions = Pick<Intl.DateTimeFormatOptions, "dateStyle" | "timeStyle">;
+
+const DEFAULT_OPTIONS: FormatDateTimeOptions = {
+  dateStyle: "medium",
+  timeStyle: "short",
+};
+
+function getFormatter(options: FormatDateTimeOptions) {
+  const key = `${options.dateStyle ?? ""}|${options.timeStyle ?? ""}`;
+  const cached = formatterCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat(LOCALE, {
+    timeZone: TIME_ZONE,
+    ...options,
+  });
+
+  formatterCache.set(key, formatter);
+  return formatter;
+}
+
+export function formatDateTime(
+  date: Date,
+  options: FormatDateTimeOptions = DEFAULT_OPTIONS,
+): string {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return getFormatter(options).format(date);
+}


### PR DESCRIPTION
## Summary
- add a shared Intl-based date formatter that fixes the locale and timezone
- switch channel and db-test pages to use the helper so rendered timestamps stay consistent between server and client

## Testing
- npm run lint
- npm run dev -- --hostname 0.0.0.0 --port 3000 (manual verification of /default/default with no hydration warnings)


------
https://chatgpt.com/codex/tasks/task_e_68cd97d4d4788328af92d2f71f83ac61