### PR TITLE
Adjust delete confirmation button styling

### DIFF
--- a/app/[boardId]/[channelId]/DeleteItemButton.tsx
+++ b/app/[boardId]/[channelId]/DeleteItemButton.tsx
@@ -116,10 +116,18 @@ function SpinnerIcon() {
 
 function ConfirmIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 2 2 22h20L12 2z" />
-      <line x1="12" y1="9" x2="12" y2="13.5" />
-      <circle cx="12" cy="17" r="0.6" fill="currentColor" stroke="none" />
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <polyline points="8.5 12.5 11.3 15.3 16 9.8" />
     </svg>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1054,9 +1054,10 @@ main > * {
 }
 
 .item-delete-button[data-state="confirm"] {
-  background: rgba(220, 38, 38, 0.75);
-  border-color: rgba(252, 165, 165, 0.95);
-  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.25);
+  background: rgba(22, 101, 52, 0.75);
+  border-color: rgba(134, 239, 172, 0.95);
+  color: rgba(240, 253, 244, 0.95);
+  box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.25);
 }
 
 .item-delete-spinner {


### PR DESCRIPTION
## Summary
- replace the delete confirmation icon with a friendly check mark
- recolor the confirmation state to use a green palette that signals success

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbafbf2db883289d527fdf6be040e4